### PR TITLE
Feature/add gcs for plugin daemon storage volume

### DIFF
--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -55,6 +55,7 @@ module "cloudrun" {
   plugin_daemon_key           = var.plugin_daemon_key
   plugin_dify_inner_api_key   = var.plugin_dify_inner_api_key
   dify_plugin_daemon_version  = var.dify_plugin_daemon_version
+  plugin_daemon_storage_name  = module.storage.plugin_daemon_storage_bucket_name
   shared_env_vars             = local.shared_env_vars
 }
 

--- a/terraform/environments/dev/provider.tf
+++ b/terraform/environments/dev/provider.tf
@@ -1,20 +1,4 @@
 terraform {
-  required_version = ">=1.5.0"
-  required_providers {
-    google = {
-      source  = "hashicorp/google"
-      version = "5.10.0"
-    }
-    google-beta = {
-      source  = "hashicorp/google-beta"
-      version = "5.10.0"
-    }
-    archive = {
-      source  = "hashicorp/archive"
-      version = "2.4.0"
-    }
-  }
-
   backend "gcs" {
     bucket = "your-tfstate-bucket" # replace with your bucket name
     prefix = "dify"

--- a/terraform/modules/cloudrun/main.tf
+++ b/terraform/modules/cloudrun/main.tf
@@ -36,7 +36,7 @@ resource "google_cloud_run_v2_service" "dify_service" {
   location = var.region
   ingress  = var.cloud_run_ingress
   template {
-    service_account = google_service_account.dify_service_account.email
+    service_account       = google_service_account.dify_service_account.email
     execution_environment = "EXECUTION_ENVIRONMENT_GEN2"
     containers {
       name  = "nginx"
@@ -188,8 +188,8 @@ resource "google_cloud_run_v2_service" "dify_service" {
         value = 2
       }
       # NOTE: Changing PM2_HOME is required for pm2 to work properly on Cloud Run Gen2 environment because of permission issues
-      env{
-        name = "PM2_HOME"
+      env {
+        name  = "PM2_HOME"
         value = "/app/web/.pm2"
       }
       env {
@@ -294,7 +294,7 @@ resource "google_cloud_run_v2_service" "dify_service" {
         }
       }
       volume_mounts {
-        name = "plugin-daemon"
+        name       = "plugin-daemon"
         mount_path = "/app/storage"
       }
     }

--- a/terraform/modules/cloudrun/variables.tf
+++ b/terraform/modules/cloudrun/variables.tf
@@ -58,6 +58,10 @@ variable "dify_plugin_daemon_version" {
   type = string
 }
 
+variable "plugin_daemon_storage_name" {
+  type = string
+}
+
 variable "shared_env_vars" {
   type = map(string)
 }

--- a/terraform/modules/storage/main.tf
+++ b/terraform/modules/storage/main.tf
@@ -9,10 +9,10 @@ resource "google_storage_bucket" "dify_storage" {
 }
 
 resource "google_storage_bucket" "plugin_daemon_storage" {
-  force_destroy               = false
-  location                    = upper(var.region)
-  name                        = "${var.project_id}_plugin-daemon-storage"
-  project                     = var.project_id
+  force_destroy = false
+  location      = upper(var.region)
+  name          = "${var.project_id}_plugin-daemon-storage"
+  project       = var.project_id
 }
 
 resource "google_service_account" "storage_admin" {

--- a/terraform/modules/storage/main.tf
+++ b/terraform/modules/storage/main.tf
@@ -8,6 +8,13 @@ resource "google_storage_bucket" "dify_storage" {
   uniform_bucket_level_access = true
 }
 
+resource "google_storage_bucket" "plugin_daemon_storage" {
+  force_destroy               = false
+  location                    = upper(var.region)
+  name                        = "${var.project_id}_plugin-daemon-storage"
+  project                     = var.project_id
+}
+
 resource "google_service_account" "storage_admin" {
   account_id   = "storage-admin-for-dify"
   display_name = "Storage Admin Service Account"

--- a/terraform/modules/storage/outputs.tf
+++ b/terraform/modules/storage/outputs.tf
@@ -5,3 +5,7 @@ output "storage_admin_key_base64" {
 output "storage_bucket_name" {
   value = google_storage_bucket.dify_storage.name
 }
+
+output "plugin_daemon_storage_bucket_name" {
+  value = google_storage_bucket.plugin_daemon_storage.name
+}


### PR DESCRIPTION
## What's Changed

- Add gcs fuse as persistent volumes of plugin daemon container

## Why?

- To make plugin daemon container's local storage persistent

## How?

- Add gcs fuse as container volumes and storage admin role to service account
- Use Cloud Run Gen 2 environment to use gcs fuse mount

## How to Test

- Checked plugin daemon container's local storage is mounted by gcs bucket

![image](https://github.com/user-attachments/assets/db8fd20a-58d9-4402-a903-de51822bc171)

## Notes

- Add `PM2_HOME` env to web container to avoid permission issues