### PR TITLE
feat: use filestore as plugin storage

### DIFF
--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -110,7 +110,7 @@ module "storage" {
 module "filestore" {
   source = "../../modules/filestore"
 
-  region     = var.region
+  region = var.region
 
   vpc_network_name = module.network.vpc_network_name
 

--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -54,9 +54,10 @@ module "cloudrun" {
   plugin_daemon_key           = var.plugin_daemon_key
   plugin_dify_inner_api_key   = var.plugin_dify_inner_api_key
   dify_plugin_daemon_version  = var.dify_plugin_daemon_version
-  plugin_daemon_storage_name  = module.storage.plugin_daemon_storage_bucket_name
   db_database                 = var.db_database
   db_database_plugin          = var.db_database_plugin
+  filestore_ip_address        = module.filestore.filestore_ip_address
+  filestore_fileshare_name    = module.filestore.filestore_fileshare_name
   shared_env_vars             = local.shared_env_vars
 
   depends_on = [google_project_service.enabled_services]
@@ -102,6 +103,16 @@ module "storage" {
   project_id                 = var.project_id
   region                     = var.region
   google_storage_bucket_name = var.google_storage_bucket_name
+
+  depends_on = [google_project_service.enabled_services]
+}
+
+module "filestore" {
+  source = "../../modules/filestore"
+
+  region     = var.region
+
+  vpc_network_name = module.network.vpc_network_name
 
   depends_on = [google_project_service.enabled_services]
 }

--- a/terraform/modules/cloudrun/main.tf
+++ b/terraform/modules/cloudrun/main.tf
@@ -271,7 +271,7 @@ resource "google_cloud_run_v2_service" "dify_service" {
       }
       env {
         name  = "PLUGIN_WORKING_PATH"
-        value = "/app/cwd"
+        value = "/app/storage/cwd"
       }
       env {
         name  = "FORCE_VERIFYING_SIGNATURE"
@@ -315,8 +315,9 @@ resource "google_cloud_run_v2_service" "dify_service" {
     }
     volumes {
       name = "plugin-daemon"
-      gcs {
-        bucket    = var.plugin_daemon_storage_name
+      nfs {
+        server = var.filestore_ip_address
+        path   = "/${var.filestore_fileshare_name}"
         read_only = false
       }
     }

--- a/terraform/modules/cloudrun/main.tf
+++ b/terraform/modules/cloudrun/main.tf
@@ -316,8 +316,8 @@ resource "google_cloud_run_v2_service" "dify_service" {
     volumes {
       name = "plugin-daemon"
       nfs {
-        server = var.filestore_ip_address
-        path   = "/${var.filestore_fileshare_name}"
+        server    = var.filestore_ip_address
+        path      = "/${var.filestore_fileshare_name}"
         read_only = false
       }
     }

--- a/terraform/modules/cloudrun/variables.tf
+++ b/terraform/modules/cloudrun/variables.tf
@@ -58,15 +58,19 @@ variable "dify_plugin_daemon_version" {
   type = string
 }
 
-variable "plugin_daemon_storage_name" {
-  type = string
-}
-
 variable "db_database" {
   type = string
 }
 
 variable "db_database_plugin" {
+  type = string
+}
+
+variable "filestore_ip_address" {
+  type = string
+}
+
+variable "filestore_fileshare_name" {
   type = string
 }
 

--- a/terraform/modules/filestore/main.tf
+++ b/terraform/modules/filestore/main.tf
@@ -1,0 +1,15 @@
+resource "google_filestore_instance" "default" {
+  name     = "dify-filestore"
+  location = "${var.region}-b"
+  tier     = "BASIC_HDD"
+
+  file_shares {
+    capacity_gb = 1024
+    name        = "share1"
+  }
+
+  networks {
+    network = var.vpc_network_name
+    modes   = ["MODE_IPV4"]
+  }
+}

--- a/terraform/modules/filestore/outputs.tf
+++ b/terraform/modules/filestore/outputs.tf
@@ -1,0 +1,7 @@
+output "filestore_ip_address" {
+  value = google_filestore_instance.default.networks[0].ip_addresses[0]
+}
+
+output "filestore_fileshare_name" {
+  value = google_filestore_instance.default.file_shares[0].name
+}

--- a/terraform/modules/filestore/variables.tf
+++ b/terraform/modules/filestore/variables.tf
@@ -1,0 +1,7 @@
+variable "region" {
+  type = string
+}
+
+variable "vpc_network_name" {
+  type = string
+}

--- a/terraform/modules/storage/main.tf
+++ b/terraform/modules/storage/main.tf
@@ -8,13 +8,6 @@ resource "google_storage_bucket" "dify_storage" {
   uniform_bucket_level_access = true
 }
 
-resource "google_storage_bucket" "plugin_daemon_storage" {
-  force_destroy = false
-  location      = upper(var.region)
-  name          = "${var.project_id}_plugin-daemon-storage"
-  project       = var.project_id
-}
-
 resource "google_service_account" "storage_admin" {
   account_id   = "storage-admin-for-dify"
   display_name = "Storage Admin Service Account"

--- a/terraform/modules/storage/outputs.tf
+++ b/terraform/modules/storage/outputs.tf
@@ -5,7 +5,3 @@ output "storage_admin_key_base64" {
 output "storage_bucket_name" {
   value = google_storage_bucket.dify_storage.name
 }
-
-output "plugin_daemon_storage_bucket_name" {
-  value = google_storage_bucket.plugin_daemon_storage.name
-}


### PR DESCRIPTION
## What's Changed

- Use Filestore (NFS) as a persistent storage volumes of plugin daemon container
- Use mounted volumes to store plugin python source code to make persistent

## Why?

- GCS FUSE could not process plugin install because of I/O restricts

## How?

- Change Cloud Run mount from GCS FUSE to Filestore

## How to Test

- Deployed on my Google Cloud environment

## Notes

- Filestore is relatively expensive resource