### PR TITLE
feat: move worker into sidecar

### DIFF
--- a/docker/api/entrypoint.sh
+++ b/docker/api/entrypoint.sh
@@ -4,7 +4,7 @@ set -e
 
 # Start a simple HTTP server for health checks
 if [[ "${MODE}" == "worker" || "${MODE}" == "beat" ]]; then
-  nohup python -m http.server 5001 &
+  nohup python -m http.server 5000 &
 fi
 
 if [[ "${MIGRATION_ENABLED}" == "true" ]]; then


### PR DESCRIPTION
## What's Changed

- Move worker container into sidecar
- solve https://github.com/DeNA/dify-google-cloud-terraform/issues/19

## Why?

- Worker could not connect to plugin and could not use knowledge function

## How?

- Modify cloud run dify service terraform configuration

## How to Test

- Could use knowledge in my deploy

## Notes

- We cannot use plugin daemon in serverless mode according to https://github.com/langgenius/dify-plugin-daemon/issues/141