### PR TITLE
Update readme add caution using tfvars

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,15 @@ This repository allows you to automatically set up Google Cloud resources using 
 
 ## Configuration
 - Set environment-specific values in the `terraform/environments/dev/terraform.tfvars` file.
+
+> [!WARNING]
+> **Security Alert: Handling `terraform.tfvars`**
+> The `terraform/environments/dev/terraform.tfvars` file in this repository is a **template only**. Populate it locally with your actual configuration (project ID, secrets, secure password).
+>
+> **Do NOT commit `terraform.tfvars` containing sensitive data to Git.** This poses a significant security risk.
+>
+> Add `*.tfvars` to your `.gitignore` file immediately to prevent accidental commits. For secure secret management, use environment variables (`TF_VAR_...`) or tools like Google Secret Manager.
+
 - Create a GCS bucket to manage Terraform state in advance, and replace "your-tfstate-bucket" in the `terraform/environments/dev/provider.tf` file with the name of the created bucket.
 
 ## Getting Started

--- a/README_ja.md
+++ b/README_ja.md
@@ -24,6 +24,14 @@
 
 ## 設定
 - `terraform/environments/dev/terraform.tfvars` ファイルで環境固有の値を設定します。
+> [!WARNING]
+> **セキュリティ警告: `terraform.tfvars` の取り扱い**
+> リポジトリ内の `terraform/environments/dev/terraform.tfvars` は **テンプレート** です。実際の値 (プロジェクトID, 機密情報, 安全なパスワード) はローカルで設定してください。
+>
+> **❗️ 機密情報を含む `terraform.tfvars` を Git にコミットしないでください。** 重大なセキュリティリスクとなります。
+>
+> 誤コミット防止のため、すぐに `*.tfvars` を `.gitignore` に追加してください。安全な管理には環境変数 (`TF_VAR_...`) や Google Secret Manager 等の利用を推奨します。
+
 - terraform stateを管理する用のGCSバケットを事前に作成し、`terraform/environments/dev/provider.tf` ファイルの "your-tfstate-bucket" を作成したバケット名に書き換えます。
 
 ## 始め方


### PR DESCRIPTION
## What's Changed

- Added an important security warning to `README.md` (and `README_ja.md`) regarding the safe handling of the `terraform.tfvars` file, using the new GitHub alert syntax (`[!WARNING]`).
- Clarified that the `terraform.tfvars` file provided is a template and should not be committed to Git repositories when populated with sensitive information or environment-specific values.
- Recommended adding `*.tfvars` to `.gitignore` and briefly mentioned alternative secure methods for managing secrets (environment variables, Secret Manager).
- Closes #21

## Why?

- The previous instructions in the README for setting up `terraform.tfvars` could inadvertently lead users to commit sensitive data (like DB passwords, secret keys, or project IDs) to their version control system.
- This poses a security risk, especially if the repository is public or shared.
- This change explicitly highlights security best practices to prevent accidental exposure and ensure users handle configuration securely.
- Addresses the concerns raised and agreed upon in issue #21 

## How?

- Modified `README.md` and `README_ja.md` by inserting a `[!WARNING]` block directly after the line mentioning the `terraform.tfvars` file in the `Configuration`/`設定` section.
- The content within the warning block advises users on the template nature of the file, the danger of committing secrets, the recommendation to use `.gitignore`, and alternative secret management strategies.
- No functional code changes were made; this PR solely updates documentation.

## How to Test

- This is a documentation-only change, so no automated tests are applicable.
- **Manual Verification:**
    1. Review the changes in `README.md` and `README_ja.md`.
    2. Confirm that the warning message is clear, accurate, and positioned correctly within the Configuration section.
    3. Verify that the `[!WARNING]` syntax renders correctly as a visible alert box when viewing the README files on GitHub (e.g., in the PR preview or after merging).
- Terraform version used for testing: N/A (Documentation change)

## Notes

- Ensured consistency by updating both the English (`README.md`) and Japanese (`README_ja.md`) documentation.
- This change aims to improve the security posture for users adopting this Terraform configuration.